### PR TITLE
Add announcement API usecase

### DIFF
--- a/api/schema/announcement.ts
+++ b/api/schema/announcement.ts
@@ -1,0 +1,3 @@
+import { Announcement as AnnouncementEntity } from '@/announcement'
+
+export type Announcement = AnnouncementEntity

--- a/api/schema/announcement.ts
+++ b/api/schema/announcement.ts
@@ -1,3 +1,6 @@
-import { Announcement as AnnouncementEntity } from '@/announcement'
-
-export type Announcement = AnnouncementEntity
+export type Announcement = {
+  announcedAt: Date
+  messageEn: string | null
+  messageZh: string | null
+  uri: string
+}

--- a/api/schema/index.ts
+++ b/api/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './localized'
+export * from './announcement'
 export * from './attendee'
 export * from './scenario'
 export * from './status'

--- a/api/usecase/announcementInfo.ts
+++ b/api/usecase/announcementInfo.ts
@@ -1,0 +1,17 @@
+import { Announcement } from '../schema'
+import { AnnouncementRepository } from './repository'
+
+export type AnnouncementReply = Announcement[]
+
+export class AnnouncementInfo {
+  private readonly announcementRepository: AnnouncementRepository
+
+  constructor(announcementRepository: AnnouncementRepository) {
+    this.announcementRepository = announcementRepository
+  }
+
+  public async listAll(): Promise<AnnouncementReply> {
+    const results = await this.announcementRepository.listAll()
+    return results
+  }
+}

--- a/api/usecase/announcementInfo.ts
+++ b/api/usecase/announcementInfo.ts
@@ -12,6 +12,18 @@ export class AnnouncementInfo {
 
   public async listAll(): Promise<AnnouncementReply> {
     const results = await this.announcementRepository.listAll()
-    return results
+    return results.map(toAnnouncementData)
   }
 }
+
+const toAnnouncementData = (data: {
+  announcedAt: Date
+  messageEn: string | null
+  messageZh: string | null
+  uri: string
+}): Announcement => ({
+  announcedAt: data.announcedAt,
+  messageEn: data.messageEn,
+  messageZh: data.messageZh,
+  uri: data.uri,
+})

--- a/api/usecase/index.ts
+++ b/api/usecase/index.ts
@@ -1,2 +1,3 @@
+export * from './announcementInfo'
 export * from './attendeeInfo'
 export * from './attendeeAccess'

--- a/api/usecase/repository.ts
+++ b/api/usecase/repository.ts
@@ -1,5 +1,10 @@
+import { Announcement } from '../../src/announcement'
 import { Attendee } from '../../src/attendee'
 import { Ruleset } from '../../src/event'
+
+export interface AnnouncementRepository {
+  listAll(): Promise<Announcement[]>
+}
 
 export interface AttendeeRepository {
   findByToken(token: string): Promise<Attendee | null>

--- a/api/usecase/repository.ts
+++ b/api/usecase/repository.ts
@@ -1,6 +1,6 @@
-import { Announcement } from '../../src/announcement'
-import { Attendee } from '../../src/attendee'
-import { Ruleset } from '../../src/event'
+import { Announcement } from '@/announcement'
+import { Attendee } from '@/attendee'
+import { Ruleset } from '@/event'
 
 export interface AnnouncementRepository {
   listAll(): Promise<Announcement[]>


### PR DESCRIPTION
#5

This adds announcement API usecase.

### Todos
- [x] Core: Add announcement domain entity #17
- [x] API: Add repo #17
- [x] API: Add usecase
- [ ] Worker: Add endpoint
- [ ] E2E test: Add scenario