### PR TITLE
Add GET /announcement non-empty data response test scenario

### DIFF
--- a/features/announcement.feature
+++ b/features/announcement.feature
@@ -6,3 +6,28 @@ Feature: Announcement
       """
       []
       """
+  @wip
+  Scenario: GET /announcement without token
+    Given there are some announcements
+      | announced_at              | message_en    | message_zh   | uri                                           | role     |
+      | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | audience |
+      | 2023-08-29 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | audience |
+    When I make a GET request to "/announcement"
+    Then the response status should be 200
+    And the response json should be:
+      """
+      [
+        {
+          "datetime": 1693267200,
+          "msgEn": "hello world 1",
+          "msgZh": "世界你好 1",
+          "uri": "https://testability.opass.app/announcements/1"
+        },
+        {
+          "datetime": 1693267200,
+          "msgEn": "hello world 2",
+          "msgZh": "世界你好 2",
+          "uri": "https://testability.opass.app/announcements/2"
+        }
+      ]
+      """

--- a/features/support/mockSteps.ts
+++ b/features/support/mockSteps.ts
@@ -1,4 +1,4 @@
-import { Given, After } from '@cucumber/cucumber'
+import { After, DataTable, Given } from '@cucumber/cucumber'
 import { WorkerWorld } from './world'
 
 Given('there have some attendees', async function (this: WorkerWorld, dataTable) {
@@ -27,6 +27,18 @@ Given(
     })
   }
 )
+
+Given('there are some announcements', async function (this: WorkerWorld, dataTable: DataTable) {
+  const announcements = dataTable.hashes().map(row =>
+    this.mock.fetch('https://testability.opass.app/announcements', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(row),
+    })
+  )
+
+  await Promise.all(announcements)
+})
 
 After(async function (this: WorkerWorld) {
   await this.mock.fetch('https://testability.opass.app/reset', {

--- a/features/support/mockSteps.ts
+++ b/features/support/mockSteps.ts
@@ -1,7 +1,7 @@
 import { After, DataTable, Given } from '@cucumber/cucumber'
 import { WorkerWorld } from './world'
 
-Given('there have some attendees', async function (this: WorkerWorld, dataTable) {
+Given('there have some attendees', async function (this: WorkerWorld, dataTable: DataTable) {
   const attendees = dataTable.hashes().map(row =>
     this.mock.fetch('https://testability.opass.app/attendees', {
       method: 'POST',


### PR DESCRIPTION
#5

This adds the (WIP) scenario where the endpoint returns non-empty data when queried without a token.

### Todos

- [x] Core: Add announcement domain entity #17
- [x] API: Add repo #17
- [x] API: Add usecase #18
- [x] E2E test: Add scenario
- [ ] Worker: Add endpoint