### PR TITLE
Flesh out GET /announcement endpoint

### DIFF
--- a/api/repository/announcements.ts
+++ b/api/repository/announcements.ts
@@ -16,7 +16,7 @@ export class D1AnnouncementRepository {
   }
 
   async listAll(): Promise<Announcement[]> {
-    const stmt = this.db.prepare('SELECT * FROM Announcement ORDER BY id')
+    const stmt = this.db.prepare('SELECT * FROM announcements ORDER BY id')
     const { results } = await stmt.all<AnnouncementSchema>()
 
     return results.map(toAnnouncement)

--- a/features/announcement.feature
+++ b/features/announcement.feature
@@ -6,7 +6,6 @@ Feature: Announcement
       """
       []
       """
-  @wip
   Scenario: GET /announcement without token
     Given there are some announcements
       | announced_at              | message_en    | message_zh   | uri                                           | role     |

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -9,12 +9,15 @@ import { Env } from './environment'
 type CF = [env: Env, context: ExecutionContext]
 
 const withUsecases = (request: IRequest, env: Env, context: ExecutionContext) => {
+  const announcementRepository = new Repository.D1AnnouncementRepository(env.DB)
   const attendeeRepository = new Repository.D1AttendeeRepository(env.DB)
   const rulesetRepository = new Repository.D1RulesetRepository(env.DB)
+  const announcementInfo = new UseCase.AnnouncementInfo(announcementRepository)
   const attendeeInfo = new UseCase.AttendeeInfo(attendeeRepository, rulesetRepository)
   const attendeeAccess = new UseCase.AttendeeAccess(attendeeRepository, rulesetRepository)
 
   Object.assign(request, {
+    announcementInfo,
     attendeeInfo,
     attendeeAccess,
   })

--- a/worker/route/announcement.ts
+++ b/worker/route/announcement.ts
@@ -1,10 +1,30 @@
 import { IRequest } from 'itty-router'
+import * as schema from '@api/schema'
+import { AnnouncementInfo } from '@api/usecase'
+import { datetimeToUnix } from '@api/utils'
 import { json } from './helper'
 
-export type AnnouncementRequest = IRequest
+export type AnnouncementRequest = {
+  announcementInfo: AnnouncementInfo
+} & IRequest
 
-export type AnnouncementResponse = Object[]
-
-export const announcement = async ({ query }: AnnouncementRequest) => {
-  return json<AnnouncementResponse>([])
+export type AnnouncementData = {
+  datetime: number
+  msgEn: string | null
+  msgZh: string | null
+  uri: string
 }
+
+export type AnnouncementResponse = AnnouncementData[]
+
+export const announcement = async ({ announcementInfo }: AnnouncementRequest) => {
+  const results = await announcementInfo.listAll();
+  return json<AnnouncementResponse>(results.map(toFormattedAnnouncement))
+}
+
+const toFormattedAnnouncement = (data: schema.Announcement): AnnouncementData => ({
+  datetime: datetimeToUnix(data.announcedAt),
+  msgEn: data.messageEn,
+  msgZh: data.messageZh,
+  uri: data.uri,
+})


### PR DESCRIPTION
#5

This fleshes out the worker endpoint `GET /announcement` when queried without a token.

### Todos

- [x] Core: Add announcement domain entity #17
- [x] API: Add repo #17
- [x] API: Add usecase #18
- [x] E2E test: Add scenario #20
- [x] Worker: Add endpoint