### PR TITLE
Add "ordering by id" to GET /announcement test scenarios

### DIFF
--- a/features/announcement.feature
+++ b/features/announcement.feature
@@ -6,15 +6,15 @@ Feature: Announcement
       """
       []
       """
-  Scenario: GET /announcement with token returns announcements based on token owner's role
+  Scenario: GET /announcement with token returns announcements based on token owner's role, ordered by id
     Given there have some attendees
       | token                                | event_id   | role  | metadata                                            | display_name | first_used_at             |
       | f185f505-d8c0-43ce-9e7b-bb9e8909072d | SITCON2023 | staff | {"_scenario_checkin": "2023-08-27 00:00:00 GMT+0" } | Aotoki       | 2023-08-20 00:00:00 GMT+0 |
     Given there are some announcements
-      | announced_at              | message_en    | message_zh   | uri                                           | roles                 |
-      | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"]          |
-      | 2023-08-29 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
-      | 2023-08-29 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]             |
+      | id | announced_at              | message_en    | message_zh   | uri                                           | roles                 |
+      | 1  | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"]          |
+      | 2  | 2023-08-29 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
+      | 3  | 2023-08-29 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]             |
     When I make a GET request to "/announcement?token=f185f505-d8c0-43ce-9e7b-bb9e8909072d"
     Then the response status should be 200
     And the response json should be:
@@ -34,12 +34,12 @@ Feature: Announcement
         }
       ]
       """
-  Scenario: GET /announcement with nonexistent token returns announcements for audiences
+  Scenario: GET /announcement with nonexistent token returns announcements for audiences, ordered by id
     Given there are some announcements
-      | announced_at              | message_en    | message_zh   | uri                                           | roles                 |
-      | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"]          |
-      | 2023-08-29 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
-      | 2023-08-29 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]             |
+      | id | announced_at              | message_en    | message_zh   | uri                                           | roles                 |
+      | 1  | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"]          |
+      | 2  | 2023-08-29 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
+      | 3  | 2023-08-29 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]             |
     When I make a GET request to "/announcement?token=f185f505-d8c0-43ce-9e7b-bb9e8909072d"
     Then the response status should be 200
     And the response json should be:
@@ -59,12 +59,12 @@ Feature: Announcement
         }
       ]
       """
-  Scenario: GET /announcement without token returns announcements for audience
+  Scenario: GET /announcement without token returns announcements for audience, ordered by id
     Given there are some announcements
-      | announced_at              | message_en    | message_zh   | uri                                           | roles        |
-      | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"] |
-      | 2023-08-29 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience"] |
-      | 2023-08-29 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]    |
+      | id | announced_at              | message_en    | message_zh   | uri                                           | roles        |
+      | 1  | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"] |
+      | 2  | 2023-08-29 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience"] |
+      | 3  | 2023-08-29 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]    |
     When I make a GET request to "/announcement"
     Then the response status should be 200
     And the response json should be:

--- a/features/support/mockSteps.ts
+++ b/features/support/mockSteps.ts
@@ -29,15 +29,11 @@ Given(
 )
 
 Given('there are some announcements', async function (this: WorkerWorld, dataTable: DataTable) {
-  const announcements = dataTable.hashes().map(row =>
-    this.mock.fetch('https://testability.opass.app/announcements', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(row),
-    })
-  )
-
-  await Promise.all(announcements)
+  await this.mock.fetch('https://testability.opass.app/announcements', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(dataTable.hashes()),
+  })
 })
 
 After(async function (this: WorkerWorld) {

--- a/mock/api/announcements.ts
+++ b/mock/api/announcements.ts
@@ -15,12 +15,41 @@ export type CreateAnnouncementPayload = {
 }
 
 export const createAnnouncementHandler = async (req: IRequest, { DB }: Env) => {
-  const { id, announced_at, message_en, message_zh, uri, roles } =
-    (await req.json()) as CreateAnnouncementPayload
   const stmt = DB.prepare(
     'INSERT INTO announcements (id, announced_at, message_en, message_zh, uri, roles) VALUES (?, ?, ?, ?, ?, ?)'
   )
-  const info = await stmt.bind(id, announced_at, message_en, message_zh, uri, roles).run()
+  const payload = await req.json<CreateAnnouncementPayload | CreateAnnouncementPayload[]>()
+
+  let info
+  if (isPayloadInArray(payload)) {
+    info = await DB.batch(
+      payload.map(data =>
+        stmt.bind(
+          data.id,
+          data.announced_at,
+          data.message_en,
+          data.message_zh,
+          data.uri,
+          data.roles
+        )
+      )
+    )
+  } else {
+    info = await stmt
+      .bind(
+        payload.id,
+        payload.announced_at,
+        payload.message_en,
+        payload.message_zh,
+        payload.uri,
+        payload.roles
+      )
+      .run()
+  }
 
   return json(info)
 }
+
+const isPayloadInArray = (
+  payload: CreateAnnouncementPayload | CreateAnnouncementPayload[]
+): payload is CreateAnnouncementPayload[] => Array.isArray(payload)

--- a/mock/api/announcements.ts
+++ b/mock/api/announcements.ts
@@ -19,37 +19,12 @@ export const createAnnouncementHandler = async (req: IRequest, { DB }: Env) => {
     'INSERT INTO announcements (id, announced_at, message_en, message_zh, uri, roles) VALUES (?, ?, ?, ?, ?, ?)'
   )
   const payload = await req.json<CreateAnnouncementPayload | CreateAnnouncementPayload[]>()
-
-  let info
-  if (isPayloadInArray(payload)) {
-    info = await DB.batch(
-      payload.map(data =>
-        stmt.bind(
-          data.id,
-          data.announced_at,
-          data.message_en,
-          data.message_zh,
-          data.uri,
-          data.roles
-        )
-      )
+  const payloadArray = Array.isArray(payload) ? payload : [payload]
+  const info = await DB.batch(
+    payloadArray.map(data =>
+      stmt.bind(data.id, data.announced_at, data.message_en, data.message_zh, data.uri, data.roles)
     )
-  } else {
-    info = await stmt
-      .bind(
-        payload.id,
-        payload.announced_at,
-        payload.message_en,
-        payload.message_zh,
-        payload.uri,
-        payload.roles
-      )
-      .run()
-  }
+  )
 
   return json(info)
 }
-
-const isPayloadInArray = (
-  payload: CreateAnnouncementPayload | CreateAnnouncementPayload[]
-): payload is CreateAnnouncementPayload[] => Array.isArray(payload)

--- a/mock/api/announcements.ts
+++ b/mock/api/announcements.ts
@@ -6,6 +6,7 @@ type Env = {
 }
 
 export type CreateAnnouncementPayload = {
+  id: number
   announced_at: number
   message_en: string
   message_zh: string
@@ -14,12 +15,12 @@ export type CreateAnnouncementPayload = {
 }
 
 export const createAnnouncementHandler = async (req: IRequest, { DB }: Env) => {
-  const { announced_at, message_en, message_zh, uri, roles } =
+  const { id, announced_at, message_en, message_zh, uri, roles } =
     (await req.json()) as CreateAnnouncementPayload
   const stmt = DB.prepare(
-    'INSERT INTO announcements (announced_at, message_en, message_zh, uri, roles) VALUES (?, ?, ?, ?, ?)'
+    'INSERT INTO announcements (id, announced_at, message_en, message_zh, uri, roles) VALUES (?, ?, ?, ?, ?, ?)'
   )
-  const info = await stmt.bind(announced_at, message_en, message_zh, uri, roles).run()
+  const info = await stmt.bind(id, announced_at, message_en, message_zh, uri, roles).run()
 
   return json(info)
 }


### PR DESCRIPTION
#5 

This adds "ordering by id" in GET /announcement test scenarios and fixes flaky tests.