### PR TITLE
Set AUTOINCRENET to prevent id reuse in "announcements"

### DIFF
--- a/migrations/0009_autoincrement_announcement_id.sql
+++ b/migrations/0009_autoincrement_announcement_id.sql
@@ -1,0 +1,21 @@
+-- Migration number: 0009 	 2023-09-01T06:22:31.739Z
+BEGIN TRANSACTION;
+
+ALTER TABLE announcements RENAME TO _announcements_old;
+
+CREATE TABLE announcements (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  announced_at DATETIME DEFAULT (datetime('NOW', 'UTC')),
+  message_en TEXT,
+  message_zh TEXT,
+  uri TEXT,
+  roles TEXT NOT NULL DEFAULT '[]'
+);
+
+INSERT INTO announcements (id, announced_at, message_en, message_zh, uri, roles)
+  SELECT id, announced_at, message_en, message_zh, uri, roles
+  FROM _announcements_old;
+
+DROP TABLE _announcements_old;
+
+COMMIT;


### PR DESCRIPTION
#5

This makes D1 table "announcements" column "id"  auto-incremented to prevent id reuse.

Ref: 
- https://www.sqlite.org/autoinc.html

> If the AUTOINCREMENT keyword appears after INTEGER PRIMARY KEY, that changes the automatic ROWID assignment algorithm to prevent the reuse of ROWIDs over the lifetime of the database. In other words, the purpose of AUTOINCREMENT is to prevent the reuse of ROWIDs from previously deleted rows.