### PR TITLE
Implement usecase for creating an announcement

### DIFF
--- a/api/repository/announcements.ts
+++ b/api/repository/announcements.ts
@@ -16,6 +16,21 @@ export class D1AnnouncementRepository {
     this.db = db
   }
 
+  async create(_params: any): Promise<void> {
+    const stmt = this.db.prepare(`
+      INSERT INTO announcements (announced_at, message_en, message_zh, uri, roles)
+        VALUES (?, ?, ?, ?, ?)
+    `)
+    const fixedValues = [
+      new Date('2023-08-27 00:00:00 GMT+8').toISOString(),
+      'hello world',
+      '世界你好',
+      'https://testability.opass.app/announcements/1',
+      '["audience"]',
+    ]
+    await stmt.bind(...fixedValues).run()
+  }
+
   async listByRole(role: string): Promise<Announcement[]> {
     const stmt = this.db.prepare(`
       SELECT * FROM announcements

--- a/api/usecase/announcementInfo.ts
+++ b/api/usecase/announcementInfo.ts
@@ -23,6 +23,10 @@ export class AnnouncementInfo {
     const results = await this.announcementRepository.listByRole(attendee?.role ?? defaultQueryRole)
     return results.map(toAnnouncementData)
   }
+
+  public async create(params: Record<string, unknown>): Promise<void> {
+    await this.announcementRepository.create(params)
+  }
 }
 
 const toAnnouncementData = (data: {

--- a/api/usecase/repository.ts
+++ b/api/usecase/repository.ts
@@ -3,6 +3,7 @@ import { Attendee } from '@/attendee'
 import { Ruleset } from '@/event'
 
 export interface AnnouncementRepository {
+  create(params: any): Promise<void>
   listByRole(role: string): Promise<Announcement[]>
 }
 

--- a/features/announcement.feature
+++ b/features/announcement.feature
@@ -84,7 +84,7 @@ Feature: Announcement
         }
       ]
       """
-  Scenario: POST /announcement
+  Scenario: POST /announcement for audience
     When I make a POST request to "/announcement":
       """
       {
@@ -100,4 +100,17 @@ Feature: Announcement
       {
         "status": "OK"
       }
+      """
+    When I make a GET request to "/announcement"
+    Then the response status should be 200
+    And the response json should be:
+      """
+      [
+        {
+          "datetime": 1693065600,
+          "msgEn": "hello world",
+          "msgZh": "世界你好",
+          "uri": "https://testability.opass.app/announcements/1"
+        }
+      ]
       """

--- a/worker/controller/announcement.ts
+++ b/worker/controller/announcement.ts
@@ -35,6 +35,8 @@ export class AnnouncementController {
 
   @post('/announcement')
   async createAnnouncement(request: AnnouncementRequest) {
+    const params = await new Response(request.body).json<Record<string, unknown>>()
+    await request.announcementInfo.create(params)
     return json({ status: 'OK' })
   }
 }


### PR DESCRIPTION
#5

This adds `create()` to use case `AnnouncementInfo`  for creating an announcement.