### PR TITLE
Add deliverer token related e2e cases to puzzle_delivery.feature

### DIFF
--- a/api/schema/puzzle.ts
+++ b/api/schema/puzzle.ts
@@ -13,7 +13,11 @@ export type DeliverPuzzlePayload = {
 export type PuzzleDeliveredResponse = {
   status: 'OK'
   /**
-   * Receiver's display name
+   * Receiver's display name.
+   *
+   * @example
+   *
+   * "Aotoki"
    */
   user_id: string
 }

--- a/api/schema/puzzle.ts
+++ b/api/schema/puzzle.ts
@@ -10,6 +10,14 @@ export type DeliverPuzzlePayload = {
   receiver: string
 }
 
+export type PuzzleDeliveredResponse = {
+  status: 'OK'
+  /**
+   * Receiver's display name
+   */
+  user_id: string
+}
+
 export type PuzzleItemStat = {
   puzzle: string
   quantity: number

--- a/features/puzzle_delivery.feature
+++ b/features/puzzle_delivery.feature
@@ -1,4 +1,39 @@
 Feature: Puzzle Delivery
+  Scenario: POST /event/puzzle/deliver with permitted token and receiver token
+    Given there have some attendees
+      | token                                | event_id   | display_name |
+      | f185f505-d8c0-43ce-9e7b-bb9e8909072d | COSCUP2023 | Aotoki       |
+    When I make a POST request to "/event/puzzle/deliver?token=1024914b-ee65-4728-b687-8341f5affa89":
+      """
+      {
+        "receiver": "f185f505-d8c0-43ce-9e7b-bb9e8909072d"
+      }
+      """
+    Then the response status should be 200
+    And the response json should be:
+      """
+      {
+        "status": "OK",
+        "user_id": "Aotoki"
+      }
+      """
+  Scenario: POST /event/puzzle/deliver with unpermitted token
+    Given there have some attendees
+      | token                                | event_id   | display_name |
+      | f185f505-d8c0-43ce-9e7b-bb9e8909072d | COSCUP2023 | Aotoki       |
+    When I make a POST request to "/event/puzzle/deliver?token=d9d09032-cdae-4da2-9f41-680ca64f2d21":
+      """
+      {
+        "receiver": "f185f505-d8c0-43ce-9e7b-bb9e8909072d"
+      }
+      """
+    Then the response status should be 400
+    And the response json should be:
+      """
+      {
+        "message": "invalid token"
+      }
+      """
   Scenario: POST /event/puzzle/deliver without token in querystring
     When I make a POST request to "/event/puzzle/deliver":
       """

--- a/worker/controller/puzzleDelivery.ts
+++ b/worker/controller/puzzleDelivery.ts
@@ -1,7 +1,8 @@
 import { IRequest, StatusError } from 'itty-router'
-import { post } from '@worker/router'
 import { AttendeeInfo } from '@api/query'
-import { DeliverPuzzlePayload } from '@api/schema'
+import * as schema from '@api/schema'
+import { post } from '@worker/router'
+import { json } from '@worker/utils'
 
 export type PuzzleDeliveryRequest = {
   attendeeInfo: AttendeeInfo
@@ -22,8 +23,20 @@ export class PuzzleDelivery {
     if (!receiver) {
       throw new StatusError(404, 'invalid receiver token')
     }
+
+    const stubbedPermittedDelivererTokens: Record<string, string> = {
+      '1024914b-ee65-4728-b687-8341f5affa89': 'Some booth',
+    }
+    if (stubbedPermittedDelivererTokens[String(delivererToken)]) {
+      return json<schema.PuzzleDeliveredResponse>({
+        status: 'OK',
+        user_id: receiver.displayName,
+      })
+    } else {
+      throw new StatusError(400, 'invalid token')
+    }
   }
 }
 
-const isDeliverPuzzleForm = (value: unknown): value is DeliverPuzzlePayload =>
+const isDeliverPuzzleForm = (value: unknown): value is schema.DeliverPuzzlePayload =>
   typeof (value as Record<string, unknown>)?.receiver === 'string'


### PR DESCRIPTION
#11

As title ([reference](https://github.com/CCIP-App/CCIP-Server/blob/5175429a0418fde9cfe636ee1107001a17343215/app/ccip.py#L272-L280)). CCIP-server's [`deliver_puzzle()` and logging behavior](https://github.com/CCIP-App/CCIP-Server/blob/5175429a0418fde9cfe636ee1107001a17343215/app/ccip.py#L273-L274) TBD.