### PR TITLE
Make announcement message extensible

### DIFF
--- a/api/command/createAnnouncement.ts
+++ b/api/command/createAnnouncement.ts
@@ -1,5 +1,5 @@
 import { Command, Repository, getCurrentTime } from '@/core'
-import { Announcement } from '@/announcement'
+import { Announcement, AnnouncementLocales } from '@/announcement'
 
 export type CreateAnnouncementInput = {
   messageEn: string | null
@@ -22,6 +22,10 @@ export class CreateAnnouncement implements Command<CreateAnnouncementInput, void
       announcedAt: getCurrentTime(),
       messageEn: input.messageEn,
       messageZh: input.messageZh,
+      message: {
+        ...(input.messageEn && { [AnnouncementLocales.enUS]: input.messageEn }),
+        ...(input.messageZh && { [AnnouncementLocales.zhTW]: input.messageZh }),
+      },
       uri: input.uri,
       roles: input.roles,
     })

--- a/api/command/createAnnouncement.ts
+++ b/api/command/createAnnouncement.ts
@@ -1,9 +1,8 @@
 import { Command, Repository, getCurrentTime } from '@/core'
-import { Announcement, AnnouncementLocales } from '@/announcement'
+import { Announcement, LocalizedText } from '@/announcement'
 
 export type CreateAnnouncementInput = {
-  messageEn: string | null
-  messageZh: string | null
+  message: LocalizedText
   uri: string
   roles: string[]
 }
@@ -20,12 +19,7 @@ export class CreateAnnouncement implements Command<CreateAnnouncementInput, void
     const announcement = new Announcement({
       id: announcementId,
       announcedAt: getCurrentTime(),
-      messageEn: input.messageEn,
-      messageZh: input.messageZh,
-      message: {
-        ...(input.messageEn && { [AnnouncementLocales.enUS]: input.messageEn }),
-        ...(input.messageZh && { [AnnouncementLocales.zhTW]: input.messageZh }),
-      },
+      message: input.message,
       uri: input.uri,
       roles: input.roles,
     })

--- a/api/projection/listAnnouncementsByAttendee.ts
+++ b/api/projection/listAnnouncementsByAttendee.ts
@@ -1,6 +1,6 @@
 import { type D1Database } from '@cloudflare/workers-types'
 import { Projection } from '@/core'
-import { Announcement } from '@/announcement'
+import { Announcement, AnnouncementLocales } from '@/announcement'
 
 type AnnouncementSchema = {
   id: string
@@ -55,6 +55,10 @@ const toAnnouncement = (data: AnnouncementSchema): Announcement => {
     announcedAt: new Date(data.announced_at),
     messageEn: data.message_en,
     messageZh: data.message_zh,
+    message: {
+      ...(data.message_en && { [AnnouncementLocales.enUS]: data.message_en }),
+      ...(data.message_zh && { [AnnouncementLocales.zhTW]: data.message_zh }),
+    },
     uri: data.uri,
     roles,
   })

--- a/api/projection/listAnnouncementsByAttendee.ts
+++ b/api/projection/listAnnouncementsByAttendee.ts
@@ -1,12 +1,11 @@
 import { type D1Database } from '@cloudflare/workers-types'
 import { Projection } from '@/core'
-import { Announcement, AnnouncementLocales } from '@/announcement'
+import { Announcement, LocalizedText } from '@/announcement'
 
 type AnnouncementSchema = {
   id: string
   announced_at: string
-  message_en: string | null
-  message_zh: string | null
+  message: string
   uri: string
   roles: string
 }
@@ -43,6 +42,13 @@ export class D1ListAnnouncementsByAttendee
 }
 
 const toAnnouncement = (data: AnnouncementSchema): Announcement => {
+  let message: LocalizedText
+  try {
+    message = JSON.parse(data.message)
+  } catch {
+    message = {}
+  }
+
   let roles: string[]
   try {
     roles = JSON.parse(data.roles)
@@ -53,10 +59,7 @@ const toAnnouncement = (data: AnnouncementSchema): Announcement => {
   return new Announcement({
     id: data.id,
     announcedAt: new Date(data.announced_at),
-    message: {
-      ...(data.message_en && { [AnnouncementLocales.enUS]: data.message_en }),
-      ...(data.message_zh && { [AnnouncementLocales.zhTW]: data.message_zh }),
-    },
+    message,
     uri: data.uri,
     roles,
   })

--- a/api/projection/listAnnouncementsByAttendee.ts
+++ b/api/projection/listAnnouncementsByAttendee.ts
@@ -53,8 +53,6 @@ const toAnnouncement = (data: AnnouncementSchema): Announcement => {
   return new Announcement({
     id: data.id,
     announcedAt: new Date(data.announced_at),
-    messageEn: data.message_en,
-    messageZh: data.message_zh,
     message: {
       ...(data.message_en && { [AnnouncementLocales.enUS]: data.message_en }),
       ...(data.message_zh && { [AnnouncementLocales.zhTW]: data.message_zh }),

--- a/api/query/listAnnouncementsByToken.ts
+++ b/api/query/listAnnouncementsByToken.ts
@@ -1,5 +1,5 @@
 import { Projection, Query, Repository } from '@/core'
-import { Announcement } from '@/announcement'
+import { Announcement, LocalizedText } from '@/announcement'
 import { Attendee, AttendeeRole } from '@/attendee'
 import { ListAnnouncementsInput } from '@api/projection'
 
@@ -9,8 +9,7 @@ export type GetAttendeeInput = {
 
 export type ListAnnouncementsOutput = {
   announcedAt: Date
-  messageEn: string | null
-  messageZh: string | null
+  message: LocalizedText
   uri: string
   roles: string[]
 }[]
@@ -35,8 +34,7 @@ export class ListAnnouncementsByToken implements Query<GetAttendeeInput, ListAnn
       (await this.announcements.query({ role: attendee?.role ?? defaultQueryRole })) ?? []
     return results.map(result => ({
       announcedAt: result.announcedAt,
-      messageEn: result.messageEn,
-      messageZh: result.messageZh,
+      message: result.message,
       uri: result.uri,
       roles: result.roles,
     }))

--- a/api/repository/announcements.ts
+++ b/api/repository/announcements.ts
@@ -1,6 +1,6 @@
 import { type D1Database } from '@cloudflare/workers-types'
 import { Repository } from '@/core'
-import { Announcement } from '@/announcement'
+import { Announcement, AnnouncementLocales } from '@/announcement'
 
 export class D1AnnouncementRepository implements Repository<Announcement> {
   private readonly db: D1Database
@@ -10,13 +10,20 @@ export class D1AnnouncementRepository implements Repository<Announcement> {
   }
 
   async save(announcement: Announcement): Promise<void> {
-    const { id, announcedAt, messageEn, messageZh, uri, roles } = announcement
+    const { id, announcedAt, message, uri, roles } = announcement
     const stmt = this.db.prepare(`
       INSERT INTO announcements (id, announced_at, message_en, message_zh, uri, roles)
         VALUES (?, ?, ?, ?, ?, ?)
     `)
     await stmt
-      .bind(id, announcedAt.toISOString(), messageEn, messageZh, uri, JSON.stringify(roles))
+      .bind(
+        id,
+        announcedAt.toISOString(),
+        message[AnnouncementLocales.enUS],
+        message[AnnouncementLocales.zhTW],
+        uri,
+        JSON.stringify(roles)
+      )
       .run()
   }
 

--- a/api/repository/announcements.ts
+++ b/api/repository/announcements.ts
@@ -1,6 +1,6 @@
 import { type D1Database } from '@cloudflare/workers-types'
 import { Repository } from '@/core'
-import { Announcement, AnnouncementLocales } from '@/announcement'
+import { Announcement } from '@/announcement'
 
 export class D1AnnouncementRepository implements Repository<Announcement> {
   private readonly db: D1Database
@@ -12,18 +12,11 @@ export class D1AnnouncementRepository implements Repository<Announcement> {
   async save(announcement: Announcement): Promise<void> {
     const { id, announcedAt, message, uri, roles } = announcement
     const stmt = this.db.prepare(`
-      INSERT INTO announcements (id, announced_at, message_en, message_zh, uri, roles)
-        VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO announcements (id, announced_at, message, uri, roles)
+        VALUES (?, ?, ?, ?, ?)
     `)
     await stmt
-      .bind(
-        id,
-        announcedAt.toISOString(),
-        message[AnnouncementLocales.enUS],
-        message[AnnouncementLocales.zhTW],
-        uri,
-        JSON.stringify(roles)
-      )
+      .bind(id, announcedAt.toISOString(), JSON.stringify(message), uri, JSON.stringify(roles))
       .run()
   }
 

--- a/api/schema/announcement.ts
+++ b/api/schema/announcement.ts
@@ -1,7 +1,6 @@
 export type Announcement = {
   announcedAt: Date
-  messageEn: string | null
-  messageZh: string | null
+  message: Record<string, string | null>
   uri: string
   roles: string[]
 }

--- a/features/announcement.feature
+++ b/features/announcement.feature
@@ -11,10 +11,10 @@ Feature: Announcement
       | token                                | event_id   | role  | metadata                                            | display_name | first_used_at             |
       | f185f505-d8c0-43ce-9e7b-bb9e8909072d | SITCON2023 | staff | {"_scenario_checkin": "2023-08-27 00:00:00 GMT+0" } | Aotoki       | 2023-08-20 00:00:00 GMT+0 |
     Given there are some announcements
-      | id                                   | announced_at              | message_en    | message_zh   | uri                                           | roles                 |
-      | 40422d68-405d-4142-979e-bce8003dcb18 | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"]          |
-      | 04058f51-09ad-4008-b767-e72086c37561 | 2023-08-30 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
-      | a163302b-32d9-4e80-a0b3-7b8ee8b1e932 | 2023-08-31 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]             |
+      | id                                   | announced_at              | message                                             | uri                                           | roles                 |
+      | 40422d68-405d-4142-979e-bce8003dcb18 | 2023-08-29 00:00:00 GMT+0 | { "en-US": "hello world 1", "zh-TW": "世界你好 1" } | https://testability.opass.app/announcements/1 | ["audience"]          |
+      | 04058f51-09ad-4008-b767-e72086c37561 | 2023-08-30 00:00:00 GMT+0 | { "en-US": "hello world 2", "zh-TW": "世界你好 2" } | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
+      | a163302b-32d9-4e80-a0b3-7b8ee8b1e932 | 2023-08-31 01:00:00 GMT+0 | { "en-US": "hello staff", "zh-TW": "工作人員你好" } | https://testability.opass.app/announcements/3 | ["staff"]             |
     When I make a GET request to "/announcement?token=f185f505-d8c0-43ce-9e7b-bb9e8909072d"
     Then the response status should be 200
     And the response json should be:
@@ -36,10 +36,10 @@ Feature: Announcement
       """
   Scenario: GET /announcement with nonexistent token returns announcements for audiences, ordered by time announced in descending order
     Given there are some announcements
-      | id                                   | announced_at              | message_en    | message_zh   | uri                                           | roles                 |
-      | 40422d68-405d-4142-979e-bce8003dcb18 | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"]          |
-      | 04058f51-09ad-4008-b767-e72086c37561 | 2023-08-30 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
-      | a163302b-32d9-4e80-a0b3-7b8ee8b1e932 | 2023-08-31 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]             |
+      | id                                   | announced_at              | message                                             | uri                                           | roles                 |
+      | 40422d68-405d-4142-979e-bce8003dcb18 | 2023-08-29 00:00:00 GMT+0 | { "en-US": "hello world 1", "zh-TW": "世界你好 1" } | https://testability.opass.app/announcements/1 | ["audience"]          |
+      | 04058f51-09ad-4008-b767-e72086c37561 | 2023-08-30 00:00:00 GMT+0 | { "en-US": "hello world 2", "zh-TW": "世界你好 2" } | https://testability.opass.app/announcements/2 | ["audience", "staff"] |
+      | a163302b-32d9-4e80-a0b3-7b8ee8b1e932 | 2023-08-31 01:00:00 GMT+0 | { "en-US": "hello staff", "zh-TW": "工作人員你好" } | https://testability.opass.app/announcements/3 | ["staff"]             |
     When I make a GET request to "/announcement?token=f185f505-d8c0-43ce-9e7b-bb9e8909072d"
     Then the response status should be 200
     And the response json should be:
@@ -61,10 +61,10 @@ Feature: Announcement
       """
   Scenario: GET /announcement without token returns announcements for audience, ordered by time announced in descending order
     Given there are some announcements
-      | id                                   | announced_at              | message_en    | message_zh   | uri                                           | roles        |
-      | 40422d68-405d-4142-979e-bce8003dcb18 | 2023-08-29 00:00:00 GMT+0 | hello world 1 | 世界你好 1   | https://testability.opass.app/announcements/1 | ["audience"] |
-      | 04058f51-09ad-4008-b767-e72086c37561 | 2023-08-30 00:00:00 GMT+0 | hello world 2 | 世界你好 2   | https://testability.opass.app/announcements/2 | ["audience"] |
-      | a163302b-32d9-4e80-a0b3-7b8ee8b1e932 | 2023-08-31 01:00:00 GMT+0 | hello staff   | 工作人員你好 | https://testability.opass.app/announcements/3 | ["staff"]    |
+      | id                                   | announced_at              | message                                             | uri                                           | roles        |
+      | 40422d68-405d-4142-979e-bce8003dcb18 | 2023-08-29 00:00:00 GMT+0 | { "en-US": "hello world 1", "zh-TW": "世界你好 1" } | https://testability.opass.app/announcements/1 | ["audience"] |
+      | 04058f51-09ad-4008-b767-e72086c37561 | 2023-08-30 00:00:00 GMT+0 | { "en-US": "hello world 2", "zh-TW": "世界你好 2" } | https://testability.opass.app/announcements/2 | ["audience"] |
+      | a163302b-32d9-4e80-a0b3-7b8ee8b1e932 | 2023-08-31 01:00:00 GMT+0 | { "en-US": "hello staff", "zh-TW": "工作人員你好" } | https://testability.opass.app/announcements/3 | ["staff"]    |
     When I make a GET request to "/announcement"
     Then the response status should be 200
     And the response json should be:

--- a/features/support/mockSteps.ts
+++ b/features/support/mockSteps.ts
@@ -38,14 +38,15 @@ Given(
 )
 
 Given('there are some announcements', async function (this: WorkerWorld, dataTable: DataTable) {
-  const toRowWithRolesAsArray = (row: Record<string, string>) => ({
+  const toRowWithJsonData = (row: Record<string, string>) => ({
     ...row,
+    message: JSON.parse(row.message),
     roles: JSON.parse(row.roles),
   })
   await createMockData(
     this.mock,
     '/announcements',
-    JSON.stringify(dataTable.hashes().map(toRowWithRolesAsArray))
+    JSON.stringify(dataTable.hashes().map(toRowWithJsonData))
   )
 })
 

--- a/migrations/0013_replace_announcement_message_columns_by_message.sql
+++ b/migrations/0013_replace_announcement_message_columns_by_message.sql
@@ -1,0 +1,25 @@
+-- Migration number: 0013 	 2023-10-01T08:36:33.178Z
+BEGIN TRANSACTION;
+
+ALTER TABLE announcements RENAME TO _announcements_old;
+
+CREATE TABLE announcements (
+  id VARCHAR(255) PRIMARY KEY,
+  announced_at DATETIME DEFAULT (datetime('NOW', 'UTC')),
+  message TEXT NOT NULL DEFAULT '{}',
+  uri TEXT,
+  roles TEXT NOT NULL DEFAULT '[]'
+);
+
+INSERT INTO announcements (id, announced_at, message, uri, roles)
+  SELECT
+    id,
+    announced_at,
+    '{"en-US":"' || message_en || '","zh-TW":"' || message_zh || '"}',
+    uri,
+    roles
+  FROM _announcements_old;
+
+DROP TABLE _announcements_old;
+
+COMMIT;

--- a/mock/api/announcements.ts
+++ b/mock/api/announcements.ts
@@ -8,8 +8,7 @@ type Env = {
 export type CreateAnnouncementPayload = {
   id: string
   announced_at: number
-  message_en: string
-  message_zh: string
+  message: string
   uri: string
   roles: string[]
 }
@@ -25,10 +24,7 @@ export const createAnnouncementHandler = async (req: IRequest, { DB }: Env) => {
       stmt.bind(
         data.id,
         data.announced_at,
-        JSON.stringify({
-          'en-US': data.message_en,
-          'zh-TW': data.message_zh,
-        }),
+        JSON.stringify(data.message),
         data.uri,
         JSON.stringify(data.roles)
       )

--- a/mock/api/announcements.ts
+++ b/mock/api/announcements.ts
@@ -16,7 +16,7 @@ export type CreateAnnouncementPayload = {
 
 export const createAnnouncementHandler = async (req: IRequest, { DB }: Env) => {
   const stmt = DB.prepare(
-    'INSERT INTO announcements (id, announced_at, message_en, message_zh, uri, roles) VALUES (?, ?, ?, ?, ?, ?)'
+    'INSERT INTO announcements (id, announced_at, message, uri, roles) VALUES (?, ?, ?, ?, ?)'
   )
   const payload = await req.json<CreateAnnouncementPayload | CreateAnnouncementPayload[]>()
   const payloadArray = Array.isArray(payload) ? payload : [payload]
@@ -25,8 +25,10 @@ export const createAnnouncementHandler = async (req: IRequest, { DB }: Env) => {
       stmt.bind(
         data.id,
         data.announced_at,
-        data.message_en,
-        data.message_zh,
+        JSON.stringify({
+          'en-US': data.message_en,
+          'zh-TW': data.message_zh,
+        }),
         data.uri,
         JSON.stringify(data.roles)
       )

--- a/src/announcement/announcement.ts
+++ b/src/announcement/announcement.ts
@@ -1,10 +1,18 @@
 import { Entity } from '@/core'
 
+export enum AnnouncementLocales {
+  zhTW = 'zh-TW',
+  enUS = 'en-US',
+}
+
+export type LocalizedText = Partial<Record<AnnouncementLocales, string>>
+
 type Attributes = {
   id: string
   announcedAt: Date
   messageEn: string | null
   messageZh: string | null
+  message: LocalizedText
   uri: string
   roles?: string[]
 }
@@ -14,6 +22,7 @@ export class Announcement implements Entity<string> {
   public readonly announcedAt: Date
   public readonly messageEn: string | null
   public readonly messageZh: string | null
+  public readonly message: LocalizedText
   public readonly uri: string
   public readonly roles: string[]
 
@@ -22,6 +31,7 @@ export class Announcement implements Entity<string> {
     this.announcedAt = attributes.announcedAt
     this.messageEn = attributes.messageEn
     this.messageZh = attributes.messageZh
+    this.message = attributes.message
     this.uri = attributes.uri
     this.roles = attributes.roles ?? []
   }

--- a/src/announcement/announcement.ts
+++ b/src/announcement/announcement.ts
@@ -10,8 +10,6 @@ export type LocalizedText = Partial<Record<AnnouncementLocales, string>>
 type Attributes = {
   id: string
   announcedAt: Date
-  messageEn: string | null
-  messageZh: string | null
   message: LocalizedText
   uri: string
   roles?: string[]
@@ -20,8 +18,6 @@ type Attributes = {
 export class Announcement implements Entity<string> {
   public readonly id: string
   public readonly announcedAt: Date
-  public readonly messageEn: string | null
-  public readonly messageZh: string | null
   public readonly message: LocalizedText
   public readonly uri: string
   public readonly roles: string[]
@@ -29,8 +25,6 @@ export class Announcement implements Entity<string> {
   constructor(attributes: Attributes) {
     this.id = attributes.id
     this.announcedAt = attributes.announcedAt
-    this.messageEn = attributes.messageEn
-    this.messageZh = attributes.messageZh
     this.message = attributes.message
     this.uri = attributes.uri
     this.roles = attributes.roles ?? []

--- a/worker/controller/announcement.ts
+++ b/worker/controller/announcement.ts
@@ -23,8 +23,10 @@ const toCreateAnnouncementParams = (
   data: schema.CreateAnnouncementPayload
 ): Command.CreateAnnouncementInput => {
   return {
-    messageEn: typeof data.msg_en === 'string' ? data.msg_en : null,
-    messageZh: typeof data.msg_zh === 'string' ? data.msg_zh : null,
+    message: {
+      ...(typeof data.msg_en === 'string' && { [schema.Languages.enUS]: data.msg_en }),
+      ...(typeof data.msg_zh === 'string' && { [schema.Languages.zhTW]: data.msg_zh }),
+    },
     uri: typeof data.uri === 'string' ? data.uri : '',
     roles: Array.isArray(data.role) ? data.role : [],
   }
@@ -34,8 +36,8 @@ export type AnnouncementResponse = AnnouncementData[]
 
 const toFormattedAnnouncement = (data: schema.Announcement): AnnouncementData => ({
   datetime: datetimeToUnix(data.announcedAt),
-  msgEn: data.messageEn,
-  msgZh: data.messageZh,
+  msgEn: data.message[schema.Languages.enUS],
+  msgZh: data.message[schema.Languages.zhTW],
   uri: data.uri,
 })
 


### PR DESCRIPTION
This allow support for new locales by merging a announcement's `messagesEn` & `messageZh` into one `message` object.